### PR TITLE
Allow a function to be passed for allowSafe

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ const url = require('url');
  *   proceed.
  * @param {Boolean=} options.strict Whether to reject requests that lack an Origin header. Defaults
  *   to true.
- * @param {Boolean=} options.allowSafe Whether to enforce the strict mode for safe requests (HEAD,
- *   GET). Defaults to true.
+ * @param {Boolean|Function=} options.allowSafe Whether to enforce the strict mode for safe requests (HEAD,
+ *   GET). Defaults to true. A function can be passed here, that will be passed req and res and should return a boolean.
  * @param {Function=} options.failure A standard connect-style callback for handling failure.
  *   Defaults to rejecting the request with 403 Unauthorized.
  */
@@ -37,8 +37,9 @@ function corsGate(options) {
     const origin = (req.headers.origin || '').toLowerCase().trim();
 
     if (!origin) {
+      const allowSafe = typeof(options.allowSafe) === 'boolean' ? options.allowSafe : options.allowSafe(req, res);
       // Fail on missing origin when in strict mode, but allow safe requests if allowSafe set.
-      if (options.strict && (!options.allowSafe || ['GET', 'HEAD'].indexOf(req.method) === -1)) {
+      if (options.strict && (!allowSafe || ['GET', 'HEAD'].indexOf(req.method) === -1)) {
         return failure(req, res, next);
       }
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function corsGate(options) {
     const origin = (req.headers.origin || '').toLowerCase().trim();
 
     if (!origin) {
-      const allowSafe = typeof(options.allowSafe) === 'boolean' ? options.allowSafe : options.allowSafe(req, res);
+      const allowSafe = !!(typeof options.allowSafe === 'function' ? options.allowSafe(req, res) : options.allowSafe);
       // Fail on missing origin when in strict mode, but allow safe requests if allowSafe set.
       if (options.strict && (!allowSafe || ['GET', 'HEAD'].indexOf(req.method) === -1)) {
         return failure(req, res, next);

--- a/package-lock.json
+++ b/package-lock.json
@@ -196,6 +196,7 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -243,6 +244,7 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
@@ -254,7 +256,8 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -495,7 +498,8 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
       "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1013,7 +1017,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1078,6 +1083,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.0.2"
       }
@@ -1194,7 +1200,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-date-object": {
       "version": "1.0.1",
@@ -1425,6 +1432,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "js-tokens": "^3.0.0"
       }
@@ -1873,7 +1881,8 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "regexpp": {
       "version": "1.1.0",
@@ -2182,7 +2191,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/test/cors-gate.spec.js
+++ b/test/cors-gate.spec.js
@@ -127,7 +127,7 @@ describe('cors-gate', function() {
         .expect(403, done);
     });
 
-    it('can be given a function', function(done) {
+    it('can be given a function returning false', function(done) {
       this.app.use(corsGate({
         strict: true,
         allowSafe: () => false,
@@ -139,6 +139,20 @@ describe('cors-gate', function() {
       request(this.app)
         .get('/get')
         .expect(403, done);
+    });
+
+    it('can be given a function returning true', function(done) {
+      this.app.use(corsGate({
+        strict: true,
+        allowSafe: () => true,
+        origin: 'http://localhost'
+      }));
+
+      this.app.get('/get', ok);
+
+      request(this.app)
+        .get('/get')
+        .expect(200, done);
     });
   });
 

--- a/test/cors-gate.spec.js
+++ b/test/cors-gate.spec.js
@@ -126,6 +126,20 @@ describe('cors-gate', function() {
         .get('/get')
         .expect(403, done);
     });
+
+    it('can be given a function', function(done) {
+      this.app.use(corsGate({
+        strict: true,
+        allowSafe: () => false,
+        origin: 'http://localhost'
+      }));
+
+      this.app.get('/get', ok);
+
+      request(this.app)
+        .get('/get')
+        .expect(403, done);
+    });
   });
 
   describe('options.strict', function() {


### PR DESCRIPTION
Allows the passing of a function for allowSafe, for when whether requests
should be considered safe is conditional based on the request or the response.