### PR TITLE
Terminate pre-flight requests

### DIFF
--- a/test/cors-gate.spec.js
+++ b/test/cors-gate.spec.js
@@ -83,6 +83,7 @@ describe('cors-gate', function() {
     request(this.app)
       .options('/post')
       .set('origin', 'http://localhost:8080')
+      .expect('Content-Length', '0')
       .expect(204, done);
   });
 

--- a/test/cors-gate.spec.js
+++ b/test/cors-gate.spec.js
@@ -71,6 +71,21 @@ describe('cors-gate', function() {
       .expect(200, done);
   });
 
+  it('should terminate on preflight requests', function(done) {
+    this.app.use(cors({
+      origin: '*'
+    }), corsGate({
+      origin: 'http://localhost'
+    }));
+
+    this.app.post('/post', ok);
+
+    request(this.app)
+      .options('/post')
+      .set('origin', 'http://localhost:8080')
+      .expect(204, done);
+  });
+
   it('should reject requests without origin', function(done) {
     this.app.use(corsGate({
       origin: 'http://localhost'


### PR DESCRIPTION
When cors-gate receives a preflight request, it should terminate that request successfully
rather than forwarding the request down to other middleware.